### PR TITLE
Support adding Free advancement, with short reason text - Resolves #5

### DIFF
--- a/src/addadvancedialog.cpp
+++ b/src/addadvancedialog.cpp
@@ -44,7 +44,8 @@ AddAdvanceDialog::AddAdvanceDialog(DataAccessLayer* dal, Character* character,QW
     proxyModel.setSourceModel(&techModel);
     proxyModel.setFilterKeyColumn(1);
 
-
+    ui->reason_label->setVisible(false);
+    ui->reason_lineEdit->setVisible(false);
 
 
     ui->detailTableView->setModel(&proxyModel);
@@ -93,7 +94,7 @@ void AddAdvanceDialog::validatePage(){
             ok &= !character->techniques.contains(name);
         }
     }
-    ok &= (ui->curriculum_radioButton->isChecked() || ui->title_radioButton->isChecked());
+    ok &= (ui->curriculum_radioButton->isChecked() || ui->title_radioButton->isChecked() || ui->free_radioButton->isChecked());
     ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(ok);
     //this->window()->adjustSize();
 
@@ -260,9 +261,17 @@ QString AddAdvanceDialog::getResult(){
     }
     if(ui->curriculum_radioButton->isChecked())
         row += "Curriculum|";
+    else if(ui->free_radioButton->isChecked()){
+        row += ui->reason_lineEdit->text().replace("|","").replace("Title","").replace("Curriculum","")+"|";
+    }
     else
         row += "Title|";
-    row += ui->xp_label->text();
+    if(ui->free_radioButton->isChecked()){
+        row+="0";
+    }
+    else{
+        row += ui->xp_label->text();
+    }
     return row;
 }
 
@@ -271,3 +280,23 @@ void AddAdvanceDialog::on_detailTableView_clicked(const QModelIndex &index)
    validatePage();
 }
 
+
+void AddAdvanceDialog::on_free_radioButton_toggled(bool checked)
+{
+   if(checked){
+       ui->reason_label->setVisible(true);
+       ui->reason_lineEdit->setVisible(true);
+       ui->xp_label->setVisible(false);
+       ui->xp_text_label->setVisible(false);
+       ui->xp_text_label2->setVisible(false);
+   }
+   else{
+       ui->reason_label->setVisible(false);
+       ui->reason_lineEdit->setVisible(false);
+       ui->xp_label->setVisible(true);
+       ui->xp_text_label->setVisible(false);
+       ui->xp_text_label2->setVisible(true);
+
+   }
+   validatePage();
+}

--- a/src/addadvancedialog.h
+++ b/src/addadvancedialog.h
@@ -53,6 +53,8 @@ private slots:
 
     void on_detailTableView_clicked(const QModelIndex &index);
 
+    void on_free_radioButton_toggled(bool checked);
+
 private:
     Ui::AddAdvanceDialog *ui;
     DataAccessLayer* dal;

--- a/ui/addadvancedialog.ui
+++ b/ui/addadvancedialog.ui
@@ -83,8 +83,11 @@
      <property name="editTriggers">
       <set>QAbstractItemView::NoEditTriggers</set>
      </property>
+     <property name="showDropIndicator" stdset="0">
+      <bool>false</bool>
+     </property>
      <property name="alternatingRowColors">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="selectionMode">
       <enum>QAbstractItemView::SingleSelection</enum>
@@ -119,7 +122,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="xp_text_label">
        <property name="text">
         <string>This will cost: </string>
        </property>
@@ -133,7 +136,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_5">
+      <widget class="QLabel" name="xp_text_label2">
        <property name="text">
         <string>XP.</string>
        </property>
@@ -159,18 +162,58 @@
      <property name="title">
       <string>Advance progress in:</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <item>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
        <widget class="QRadioButton" name="curriculum_radioButton">
         <property name="text">
          <string>Curriculum</string>
         </property>
        </widget>
       </item>
-      <item>
+      <item row="0" column="1">
        <widget class="QRadioButton" name="title_radioButton">
         <property name="text">
          <string>Title</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="reason_label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Reason:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="reason_lineEdit">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maxLength">
+           <number>15</number>
+          </property>
+          <property name="placeholderText">
+           <string>Tattoo, GM Award</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <widget class="QRadioButton" name="free_radioButton">
+        <property name="text">
+         <string>Free (None)</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This allows users to choose 'Free' advancements and specify a reason.  For Togashi, they could add a Free Kiho and enter 'Tattoo' to reflect the source.  As a pleasant side effect, this should also support GM fiat advances!