### PR TITLE
DataAccessLayer query execution helper

### DIFF
--- a/PaperBlossoms/src/dataaccesslayer.cpp
+++ b/PaperBlossoms/src/dataaccesslayer.cpp
@@ -104,18 +104,21 @@ QStringList DataAccessLayer::qsl_getclans()
 
 QStringList DataAccessLayer::qsl_getfamilies(const QString clan)
 {
-    QStringList out;
-    //family query
-    QSqlQuery query;
-    query.prepare("SELECT name FROM families WHERE clan = :clan ORDER BY name");
-    query.bindValue(0, clan);
-    query.exec();
-    while (query.next()) {
-        const QString fname = query.value(0).toString();
-        out << fname;
-//        qDebug() << fname;
-    }
-    return out;
+    const QString query = "SELECT name FROM families WHERE clan = :clan ORDER BY name";
+    const SqlQueryValueBindingCollection bindings = {
+        SqlQueryValueBinding{ 0, clan }
+    };
+    return executeAndHandleQuery(query, bindings,
+        [](QSqlQuery& query) {
+            QStringList out;
+            while (query.next()) {
+                const QString fname = query.value(0).toString();
+                out << fname;
+                //qDebug() << fname;
+            }
+            return out;
+        }
+    );
 }
 
 QString DataAccessLayer::qs_getclandesc(const QString clan)
@@ -1698,4 +1701,15 @@ bool DataAccessLayer::importCSV(const QString filepath, const QString tablename)
         f.close ();
     }
     return success;
+}
+
+QStringList DataAccessLayer::executeAndHandleQuery(const QString& queryString, const SqlQueryValueBindingCollection& bindings, const std::function<QStringList(QSqlQuery& executedQuery)>& queryExecutionCallback) {
+    QSqlQuery query;
+    query.prepare(queryString);
+    for (const SqlQueryValueBinding& valueBinding : bindings) {
+        query.bindValue(valueBinding.pos, valueBinding.val);
+    }
+    query.exec();
+
+    return queryExecutionCallback(query);
 }

--- a/PaperBlossoms/src/dataaccesslayer.h
+++ b/PaperBlossoms/src/dataaccesslayer.h
@@ -141,12 +141,20 @@ public:
     QStringList qsl_getpatterns();
     QString qs_getringdesc(const QString ring);
 private:
+    struct SqlQueryValueBinding {
+        int pos;
+        QVariant val;
+    };
+    typedef std::vector<const SqlQueryValueBinding> SqlQueryValueBindingCollection;
+
     QSqlDatabase db;
     QStringList qsl_getschooltechsetids(const QString school);
     QStringList qsl_getschoolequipsetids(const QString school);
     QString getLastExecutedQuery(const QSqlQuery &query);
     QString escapedCSV(QString unexc);
     QStringList parseCSV(const QString &string);
+
+    QStringList executeAndHandleQuery(const QString& queryString, const SqlQueryValueBindingCollection& bindings, const std::function<QStringList(QSqlQuery& executedQuery)>& queryExecutionCallback);
 };
 
 #endif // DATAACCESSLAYER_H


### PR DESCRIPTION
Here's the helper function with the lambda callback I was talking about.  It's mainly about separation of responsibility and reducing code duplication.  

The various public APIs on the DataAccessLayer would just be concerned with the context of their query:  defining the query and parsing the result.

The helper is responsible for constructing the QSql* related objects and executing the query.  The executed query is then handed off to the public API defined callback lambda to parse the result.  

Let me know what you think and I can refactor all of the queries.  I'll probably need another helper that just returns a QString instead of a QStringList, but whatevs.