### PR TITLE
Qt 5_15_2 on M1 required a QCloseEvent to compile.  Shouldn't harm ot…

### DIFF
--- a/PaperBlossoms/src/mainwindow.cpp
+++ b/PaperBlossoms/src/mainwindow.cpp
@@ -55,6 +55,7 @@
 #include "edituserdescriptionsdialog.h"
 #include "dblocalisationeditordialog.h"
 #include <QFileInfo>
+#include <QCloseEvent>
 
 
 


### PR DESCRIPTION
…her build envs. Added for compatibility.