### PR TITLE
Check for valid index before calling technique click code. 

### DIFF
--- a/PaperBlossoms/src/addadvancedialog.cpp
+++ b/PaperBlossoms/src/addadvancedialog.cpp
@@ -580,7 +580,9 @@ void AddAdvanceDialog::on_free_radioButton_toggled(const bool checked)
 void AddAdvanceDialog::on_halfxp_checkBox_toggled(bool checked)
 {
     Q_UNUSED(checked);
-    on_detailTableView_clicked(ui->detailTableView->currentIndex());
+    if(ui->advtype->currentText() == "Technique" && ui->detailTableView->currentIndex().isValid()){
+        on_detailTableView_clicked(ui->detailTableView->currentIndex());
+    }
     on_advchooser_combobox_currentIndexChanged(ui->advchooser_combobox->currentText());
     validatePage();
 }


### PR DESCRIPTION
Prevents crash when adjusting spec train without a technique selected.  Resolves #226 